### PR TITLE
Issue 21: Not able to import 'JSON' data using apoc.import.json procedure

### DIFF
--- a/core/src/main/java/apoc/export/json/JsonFormat.java
+++ b/core/src/main/java/apoc/export/json/JsonFormat.java
@@ -28,6 +28,9 @@ import java.util.function.Consumer;
 
 
 public class JsonFormat implements Format {
+    public static final String RELS = "rels";
+    public static final String NODES = "nodes";
+
     enum Format {JSON_LINES, ARRAY_JSON, JSON, JSON_ID_AS_KEYS}
     private final GraphDatabaseService db;
     private final Format format;
@@ -89,11 +92,11 @@ public class JsonFormat implements Format {
     private void writeJsonRelationshipContainerStart(JsonGenerator jsonGenerator) throws IOException {
         switch (format) {
             case JSON:
-                jsonGenerator.writeFieldName("rels");
+                jsonGenerator.writeFieldName(RELS);
                 jsonGenerator.writeStartArray();
                 break;
             case JSON_ID_AS_KEYS:
-                jsonGenerator.writeFieldName("rels");
+                jsonGenerator.writeFieldName(RELS);
                 jsonGenerator.writeStartObject();
                 break;
         }
@@ -114,12 +117,12 @@ public class JsonFormat implements Format {
         switch (format) {
             case JSON:
                 jsonGenerator.writeStartObject();
-                jsonGenerator.writeFieldName("nodes");
+                jsonGenerator.writeFieldName(NODES);
                 jsonGenerator.writeStartArray();
                 break;
             case JSON_ID_AS_KEYS:
                 jsonGenerator.writeStartObject();
-                jsonGenerator.writeFieldName("nodes");
+                jsonGenerator.writeFieldName(NODES);
                 jsonGenerator.writeStartObject();
                 break;
         }
@@ -270,10 +273,10 @@ public class JsonFormat implements Format {
     private void writePath(Reporter reporter, JsonGenerator jsonGenerator, ExportConfig config, Path path) throws IOException {
         jsonGenerator.writeStartObject();
         jsonGenerator.writeObjectField("length", path.length());
-        jsonGenerator.writeArrayFieldStart("rels");
+        jsonGenerator.writeArrayFieldStart(RELS);
         writeRels(path.relationships(), reporter, jsonGenerator, config);
         jsonGenerator.writeEndArray();
-        jsonGenerator.writeArrayFieldStart("nodes");
+        jsonGenerator.writeArrayFieldStart(NODES);
         writeNodes(path.nodes(), reporter, jsonGenerator, config);
         jsonGenerator.writeEndArray();
         jsonGenerator.writeEndObject();


### PR DESCRIPTION
Issue 21

Non so se possa essere visto come un bug o una funzionalità aggiuntiva non implementata, in quando inizialmente la configurazione di export `jsonFormat` non c'era.

Al momento l'ho implementato in modo che venga riconosciuto il tipo di json esportato.

Si potrebbe anche creare un config `jsonFormat` analogo anche nell'import evitando gli ` instanceof Map` e simili.


Oppure più semplicemente cambiare nella documentazione
```
The `apoc.import.json` procedure can be used to import JSON files created by the `apoc.export.json.*` procedures.
```
con ad esempio
```
The `apoc.import.json` procedure can be used to import JSON files created by the `apoc.export.json.*` procedures, exported using the config parameter `jsonFormat: 'JSON_LINES'` (default config).
```
ma renderebbe il json esportato in altri formati poco utile credo
