### PR TITLE
Fix flaky XmlTest due to SocketTimeoutException

### DIFF
--- a/common/src/main/java/apoc/util/Util.java
+++ b/common/src/main/java/apoc/util/Util.java
@@ -114,6 +114,8 @@ public class Util {
     public static final String REL_COUNT = "MATCH ()-->() RETURN count(*) as result";
     public static final String COMPILED = "interpreted"; // todo handle enterprise properly
     public static final String ERROR_BYTES_OR_STRING = "Only byte[] or url String allowed";
+    public static final String APOC_HTTP_TIMEOUT_CONNECT = "apoc.http.timeout.connect";
+    public static final String APOC_HTTP_TIMEOUT_READ = "apoc.http.timeout.read";
 
     public static String labelString(List<String> labelNames) {
         return labelNames.stream().map(Util::quote).collect(Collectors.joining(":"));
@@ -342,8 +344,8 @@ public class Util {
             headers.forEach((k,v) -> con.setRequestProperty(k, v == null ? "" : v.toString()));
         }
 //        con.setDoInput(true);
-        con.setConnectTimeout(apocConfig().getInt("apoc.http.timeout.connect",10_000));
-        con.setReadTimeout(apocConfig().getInt("apoc.http.timeout.read",60_000));
+        con.setConnectTimeout(apocConfig().getInt(APOC_HTTP_TIMEOUT_CONNECT,10_000));
+        con.setReadTimeout(apocConfig().getInt(APOC_HTTP_TIMEOUT_READ,60_000));
         return con;
     }
 

--- a/core/src/test/java/apoc/load/XmlTest.java
+++ b/core/src/test/java/apoc/load/XmlTest.java
@@ -31,6 +31,8 @@ import static apoc.ApocConfig.apocConfig;
 import static apoc.util.BinaryTestUtil.fileToBinary;
 import static apoc.util.CompressionConfig.COMPRESSION;
 import static apoc.util.TestUtil.*;
+import static apoc.util.Util.APOC_HTTP_TIMEOUT_CONNECT;
+import static apoc.util.Util.APOC_HTTP_TIMEOUT_READ;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.*;
 import static org.neo4j.internal.helpers.collection.MapUtil.map;
@@ -48,6 +50,8 @@ public class XmlTest {
     public void setUp() throws Exception {
         apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, true);
         apocConfig().setProperty(APOC_IMPORT_FILE_USE_NEO4J_CONFIG, false);
+        apocConfig().setProperty(APOC_HTTP_TIMEOUT_CONNECT, 20_000);
+        apocConfig().setProperty(APOC_HTTP_TIMEOUT_READ, 120_000);
         TestUtil.registerProcedure(db, Xml.class);
     }
 


### PR DESCRIPTION
Fix flaky XmlTest due to SocketTimeoutException
https://trello.com/c/FO9tIWDL/1096-essential-builds-failure-apocloadxmltesttestloadxmlfromzipbyurl-is-failing-on-a-dev-essential-build

-----

Visto che l'eccezione si ha quando si legge l'url https://github.com/neo4j-contrib/neo4j-apoc-procedures/blob/3.4/src/test/resources/testload.zip?raw=true!xml/books.xml credo che l'unica soluzione sia aumentare il timeout.

Ho aumentato sia il `setReadTimeout` per cercare di risolvere la card di sopra, sia il `setConnectTimeout` per prevenire "Connect timed out", e.g. in https://trello.com/c/g06vJGtc/951-essential-builds-failure-apocloadxmltesttestloadxmlfromtargzbyurl-is-failing-on-a-dev-essential-build?search_id=0b3b4048-6ce6-44fd-9469-726d051c66b5 