### PR TITLE
Issue 35: Round trip with apoc graphml coerces types to string

### DIFF
--- a/common/src/main/java/apoc/export/util/MetaInformation.java
+++ b/common/src/main/java/apoc/export/util/MetaInformation.java
@@ -12,11 +12,13 @@ import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.ResultTransformer;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static apoc.gephi.GephiFormatUtils.getCaption;
@@ -89,6 +91,28 @@ public class MetaInformation {
             if (storedClass == void.class || storedClass.equals(value.getClass())) continue;
             keyTypes.put(prop, void.class);
         }
+    }
+
+    public static void updateKeyTypesForGraphMl(Map<String, Map<Class, String>> keyTypes, Entity pc, boolean useTypes) {
+        for (String prop : pc.getPropertyKeys()) {
+            Object value = pc.getProperty(prop);
+
+            final Map<Class, String> propSubMap = keyTypes.get(prop);
+            final Class clazz = value.getClass();
+            if (propSubMap == null) {
+                initPropKey(keyTypes, prop, clazz);
+                continue;
+            }
+            propSubMap.putIfAbsent(clazz, getPropSuffix(useTypes));
+        }
+    }
+
+    public static void initPropKey(Map<String, Map<Class, String>> keyTypes, String prop, Class<?> value) {
+        keyTypes.put(prop, new HashMap<>(Map.of(value, "")));
+    }
+
+    public static String getPropSuffix(boolean useTypes) {
+        return useTypes ? "_" + UUID.randomUUID() : "";
     }
 
     public final static Set<String> GRAPHML_ALLOWED = new HashSet<>(asList("boolean", "int", "long", "float", "double", "string"));

--- a/common/src/main/java/apoc/meta/Types.java
+++ b/common/src/main/java/apoc/meta/Types.java
@@ -22,7 +22,7 @@ public enum Types {
 
     private String typeOfList = "ANY";
 
-    private static Map<Class<?>, Class<?>> primitivesMapping = new HashMap(){{
+    public static Map<Class<?>, Class<?>> primitivesMapping = new HashMap(){{
         put(double.class, Double.class);
         put(float.class, Float.class);
         put(int.class, Integer.class);

--- a/core/src/main/java/apoc/export/graphml/ExportGraphML.java
+++ b/core/src/main/java/apoc/export/graphml/ExportGraphML.java
@@ -120,7 +120,7 @@ public class ExportGraphML {
         apocConfig.checkWriteAllowed(exportConfig, fileName);
         final String format = "graphml";
         ProgressReporter reporter = new ProgressReporter(null, null, new ProgressInfo(fileName, source, format));
-        XmlGraphMLWriter exporter = new XmlGraphMLWriter();
+        XmlGraphMLWriter exporter = new XmlGraphMLWriter(tx);
         ExportFileManager cypherFileManager = FileManagerFactory.createFileManager(fileName, false, exportConfig);
         final PrintWriter graphMl = cypherFileManager.getPrintWriter(format);
         if (exportConfig.streamStatements()) {

--- a/core/src/main/java/apoc/export/graphml/XmlGraphMLFormat.java
+++ b/core/src/main/java/apoc/export/graphml/XmlGraphMLFormat.java
@@ -30,7 +30,7 @@ public class XmlGraphMLFormat implements Format {
     @Override
     public ProgressInfo dump(SubGraph graph, ExportFileManager writer, Reporter reporter, ExportConfig config) throws Exception {
         try (Transaction tx = db.beginTx()) {
-            XmlGraphMLWriter graphMlWriter = new XmlGraphMLWriter();
+            XmlGraphMLWriter graphMlWriter = new XmlGraphMLWriter(tx);
             graphMlWriter.write(graph, writer.getPrintWriter("graphml"), reporter, config);
             tx.commit();
         }

--- a/core/src/main/java/apoc/export/graphml/XmlGraphMLWriter.java
+++ b/core/src/main/java/apoc/export/graphml/XmlGraphMLWriter.java
@@ -7,6 +7,7 @@ import org.neo4j.graphdb.Entity;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.NotFoundException;
 import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.Transaction;
 
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
@@ -24,6 +25,12 @@ import static apoc.export.util.MetaInformation.*;
  */
 public class XmlGraphMLWriter {
     private final Map<String, Map<Class, String>> totalKeyTypes = new HashMap<>();
+    private final Transaction tx;
+
+    public XmlGraphMLWriter(Transaction tx) {
+        this.tx = tx;
+    }
+    
     public void write(SubGraph graph, Writer writer, Reporter reporter, ExportConfig config) throws Exception {
         XMLOutputFactory xmlOutputFactory = XMLOutputFactory.newInstance();
         XMLStreamWriter xmlWriter = xmlOutputFactory.createXMLStreamWriter(writer);


### PR DESCRIPTION
Issue 35

In case of multiple property found via `apoc.meta.*` with same name but different class type, 
an additional `"__metaType"` suffix will be added  to attributes `id` and tag key, and to `key` attributes and tag `data`, 
e.g. `<key id="alpha__Integer" .../>` 


TODO - documentation, in repo `neo4j/docs-apoc`