### PR TITLE
Issue 157: FTP/SFTP support for loading data (JSON, XML)

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -49,6 +49,8 @@ dependencies {
         exclude group: 'com.fasterxml.jackson.core', module: 'jackson-annotations'
         exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
     }
+    
+    def jschVersion = '0.1.55'
 
     // These will be dependencies packaged with the .jar
     api group: 'com.jayway.jsonpath', name: 'json-path', version: '2.7.0'
@@ -69,6 +71,7 @@ dependencies {
     // These will be dependencies not packaged with the .jar
     // They need to be provided either through the database or in an extra .jar
     compileOnly group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective
+    compileOnly group: 'com.jcraft', name: 'jsch', version: jschVersion
     compileOnly group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.270'
     compileOnly group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.2', withoutServers
     compileOnly group: 'com.google.cloud', name: 'google-cloud-storage', version: '2.6.1'
@@ -76,6 +79,7 @@ dependencies {
     // These dependencies affect the tests only, they will not be packaged in the resulting .jar
     testImplementation project(':test-utils')
     testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.270'
+    testImplementation group: 'com.jcraft', name: 'jsch', version: jschVersion
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation group: 'com.github.stefanbirkner', name: 'system-rules', version: '1.19.0'
     testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: '1.3'

--- a/common/src/main/java/apoc/util/FileUtils.java
+++ b/common/src/main/java/apoc/util/FileUtils.java
@@ -7,6 +7,7 @@ import apoc.export.util.ExportConfig;
 import apoc.util.hdfs.HDFSUtils;
 import apoc.util.s3.S3URLConnection;
 import apoc.util.s3.S3UploadUtils;
+import apoc.util.sftp.SftpURLConnection;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.neo4j.configuration.GraphDatabaseSettings;
@@ -44,6 +45,7 @@ public class FileUtils {
         http(true, null),
         https(true, null),
         ftp(true, null),
+        sftp(Util.classExists("com.jcraft.jsch.JSch"), "apoc.util.sftp.SftpURLStreamHandlerFactory"),
         s3(Util.classExists("com.amazonaws.services.s3.AmazonS3"),
                 "apoc.util.s3.S3UrlStreamHandlerFactory"),
         gs(Util.classExists("com.google.cloud.storage.Storage"),
@@ -67,6 +69,8 @@ public class FileUtils {
                     return FileUtils.openS3InputStream(urlAddress);
                 case hdfs:
                     return FileUtils.openHdfsInputStream(urlAddress);
+                case sftp:
+                    return FileUtils.openSftpInputStream(urlAddress);
                 case ftp:
                 case http:
                 case https:
@@ -281,6 +285,14 @@ public class FileUtils {
                     "\nSee the documentation: https://neo4j.github.io/apoc/#_loading_data_from_web_apis_json_xml_csv");
         }
         return S3URLConnection.openS3InputStream(new URL(urlAddress));
+    }
+
+    public static StreamConnection openSftpInputStream(String urlAddress) throws IOException {
+        if (!SupportedProtocols.sftp.isEnabled()) {
+            throw new MissingDependencyException("Cannot find the jsch jar in the plugins folder. \n" +
+                    "Please, add this jar into the plugins folder: https://repo1.maven.org/maven2/com/jcraft/jsch/0.1.55/jsch-0.1.55.jar");
+        }
+        return SftpURLConnection.openSftpInputStream(new URL(urlAddress));
     }
 
     public static StreamConnection openHdfsInputStream(String urlAddress) throws IOException {

--- a/common/src/main/java/apoc/util/sftp/SftpURLConnection.java
+++ b/common/src/main/java/apoc/util/sftp/SftpURLConnection.java
@@ -1,0 +1,77 @@
+package apoc.util.sftp;
+
+import apoc.util.StreamConnection;
+import com.jcraft.jsch.ChannelSftp;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.Session;
+import com.jcraft.jsch.SftpException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
+
+public class SftpURLConnection extends URLConnection {
+
+    @Override
+    public void connect() {}
+
+    public SftpURLConnection(URL url) {
+        super(url);
+    }
+
+    public static StreamConnection openSftpInputStream(URL url) {
+        try {
+            JSch jsch = new JSch();
+            String username = null;
+            String password = null;
+            final String userInfo = url.getUserInfo();
+            if (userInfo != null) {
+                String[] credentials = userInfo.split(":");
+                username = credentials[0];
+                password = credentials[1];
+            }
+            final Session session = jsch.getSession(username, url.getHost(), url.getPort());
+            // todo: StrictHostKeyChecking could be configurable
+            session.setConfig("StrictHostKeyChecking", "no");
+            session.setPassword(password);
+
+            session.connect();
+
+            final ChannelSftp channelSftp = (ChannelSftp) session.openChannel(url.getProtocol());
+            channelSftp.connect();
+
+            final InputStream inputStream = channelSftp.get(url.getFile());
+
+            return new StreamConnection() {
+                @Override
+                public InputStream getInputStream() {
+                    return inputStream;
+                }
+
+                @Override
+                public String getEncoding() {
+                    return "";
+                }
+
+                @Override
+                public long getLength() {
+                    try {
+                        return inputStream.available();
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+
+                @Override
+                public String getName() {
+                    return url.getFile();
+                }
+            };
+        } catch (JSchException | SftpException e) {
+            throw new RuntimeException(e);
+        }
+    }
+ 
+}

--- a/common/src/main/java/apoc/util/sftp/SftpURLStreamHandlerFactory.java
+++ b/common/src/main/java/apoc/util/sftp/SftpURLStreamHandlerFactory.java
@@ -1,0 +1,19 @@
+package apoc.util.sftp;
+
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+import java.net.URLStreamHandlerFactory;
+
+public class SftpURLStreamHandlerFactory implements URLStreamHandlerFactory {
+    
+    @Override
+    public URLStreamHandler createURLStreamHandler(String protocol) {
+        return new URLStreamHandler() {
+            @Override
+            protected URLConnection openConnection(URL url) {
+                return new SftpURLConnection(url);
+            }
+        };
+    }
+}

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -89,8 +89,10 @@ dependencies {
     testImplementation group: 'com.github.stefanbirkner', name: 'system-rules', version: '1.19.0'
     testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.270'
     testImplementation group: 'org.mock-server', name: 'mockserver-netty', version: '5.6.0'
+    testImplementation group: 'org.mockftpserver', name: 'MockFtpServer', version: '3.1.0'
     testImplementation group: 'com.github.adejanovski', name: 'cassandra-jdbc-wrapper', version: '3.1.0'
     testImplementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-csv', version: '2.13.2'
+    testImplementation group: 'com.github.stefanbirkner', name: 'fake-sftp-server-rule', version: '2.0.1'
 
     configurations.all {
         exclude group: 'org.slf4j', module: 'slf4j-nop'

--- a/core/src/test/java/apoc/load/FtpLoadTest.java
+++ b/core/src/test/java/apoc/load/FtpLoadTest.java
@@ -1,0 +1,76 @@
+package apoc.load;
+
+import apoc.util.TestUtil;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.mockftpserver.fake.FakeFtpServer;
+import org.mockftpserver.fake.UserAccount;
+import org.mockftpserver.fake.filesystem.FileEntry;
+import org.mockftpserver.fake.filesystem.FileSystem;
+import org.mockftpserver.fake.filesystem.UnixFakeFileSystem;
+import org.neo4j.test.rule.DbmsRule;
+import org.neo4j.test.rule.ImpermanentDbmsRule;
+
+import java.util.Map;
+
+import static apoc.util.MapUtil.map;
+import static apoc.util.TestUtil.testCall;
+import static org.junit.Assert.assertEquals;
+
+
+public class FtpLoadTest {
+    private static final String PASSWORD = "password";
+    private static final String USERNAME = "admin";
+    private static final String JSON_FILE_NAME = "/subdir/sample.json";
+    private static final String XML_FILE_NAME = "/subdir/sample.xml";
+    private static String HOST;
+
+    @ClassRule
+    public static DbmsRule db = new ImpermanentDbmsRule();
+
+    private static FakeFtpServer ftpServer;
+
+
+    @BeforeClass
+    public static void beforeClass() {
+        ftpServer = new FakeFtpServer();
+
+        FileSystem fileSystem = new UnixFakeFileSystem();
+        ftpServer.setFileSystem(fileSystem);
+
+        UserAccount userAccount = new UserAccount(USERNAME, PASSWORD, "/");
+        ftpServer.addUserAccount(userAccount);
+
+        ftpServer.start();
+        
+        fileSystem.add(new FileEntry(JSON_FILE_NAME, "{a: 1}"));
+        
+        fileSystem.add(new FileEntry(XML_FILE_NAME, "<catalog>1</catalog>"));
+
+        TestUtil.registerProcedure(db, LoadJson.class, Xml.class);
+
+        HOST = String.format("ftp://%s:%s@localhost:%s",
+                USERNAME, PASSWORD, ftpServer.getServerControlPort());
+    }
+
+    @AfterClass
+    public static void afterClass()  {
+        ftpServer.stop();
+    }
+    
+    @Test
+    public void testLoadJsonFtp() {
+        testCall(db, "CALL apoc.load.json($url)",
+                map("url", HOST + JSON_FILE_NAME),
+                (row) -> assertEquals(Map.of("a", 1L), row.get("value")));
+    }
+    
+    @Test
+    public void testLoadXmlFtp()  {
+        testCall(db, "CALL apoc.load.xml($url)",
+                map("url", HOST + XML_FILE_NAME),
+                (row) -> assertEquals(Map.of("_type", "catalog", "_text", "1"), row.get("value")));
+    }
+}

--- a/core/src/test/java/apoc/load/SftpLoadTest.java
+++ b/core/src/test/java/apoc/load/SftpLoadTest.java
@@ -1,0 +1,57 @@
+package apoc.load;
+
+import apoc.util.TestUtil;
+import com.github.stefanbirkner.fakesftpserver.rule.FakeSftpServerRule;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.neo4j.test.rule.DbmsRule;
+import org.neo4j.test.rule.ImpermanentDbmsRule;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static apoc.util.MapUtil.map;
+import static apoc.util.TestUtil.testCall;
+import static org.junit.Assert.assertEquals;
+
+public class SftpLoadTest {
+    private static final String USERNAME = "admin";
+    private static final String PASSWORD = "password";
+    private static final String JSON_FILE_NAME = "/subdir/sample.json";
+    private static final String XML_FILE_NAME = "/subdir/sample.xml";
+    
+    private static String HOST;
+
+    @ClassRule
+    public static DbmsRule db = new ImpermanentDbmsRule();
+
+    @ClassRule
+    public static final FakeSftpServerRule sftpServer = new FakeSftpServerRule()
+            .addUser(USERNAME, PASSWORD);
+
+    @BeforeClass
+    public static void beforeClass() throws IOException {
+        sftpServer.putFile(JSON_FILE_NAME, "{a: 1}", StandardCharsets.UTF_8);
+        sftpServer.putFile(XML_FILE_NAME, "<catalog>1</catalog>", StandardCharsets.UTF_8);
+        TestUtil.registerProcedure(db, LoadJson.class, Xml.class);
+
+        HOST = String.format("sftp://%s:%s@localhost:%s",
+                USERNAME, PASSWORD, sftpServer.getPort());
+    }
+
+    @Test
+    public void testLoadJsonFtp() {
+        testCall(db, "CALL apoc.load.json($url)",
+                map("url", HOST + JSON_FILE_NAME),
+                (row) -> assertEquals(Map.of("a", 1L), row.get("value")));
+    }
+
+    @Test
+    public void testLoadXmlFtp()  {
+        testCall(db, "CALL apoc.load.xml($url)",
+                map("url", HOST + XML_FILE_NAME),
+                (row) -> assertEquals(Map.of("_type", "catalog", "_text", "1"), row.get("value")));
+    }
+}


### PR DESCRIPTION
Issue 157

Implemented sftp support similarly to s3 protocol.
Added tests with sftp / ftp.

Card: https://trello.com/c/qyzuDr0h/1416-add-ftp-sftp-support-for-loading-data-json-csv-xml-etc


TODO: update docs in `neo4j/docs-apoc`
TODO: test with apoc.load.csv (in extended)