### PR TITLE
wip - schema nodes/rels

### DIFF
--- a/core/src/main/java/apoc/schema/Schemas.java
+++ b/core/src/main/java/apoc/schema/Schemas.java
@@ -56,6 +56,7 @@ import static org.neo4j.internal.schema.SchemaUserDescription.TOKEN_LABEL;
 import static org.neo4j.internal.schema.SchemaUserDescription.TOKEN_REL_TYPE;
 
 public class Schemas {
+    private static final String IDX_NOT_FOUND = "NOT_FOUND";
 
     @Context
     public Transaction tx;
@@ -336,6 +337,7 @@ public class Schemas {
      * @return
      */
     private Stream<IndexConstraintNodeInfo> indexesAndConstraintsForNode(Map<String,Object> config) {
+        Schema schema = tx.schema();
 
         SchemaConfig schemaConfig = new SchemaConfig(config);
         Set<String> includeLabels = schemaConfig.getLabels();
@@ -346,9 +348,10 @@ public class Schemas {
 
             SchemaRead schemaRead = ktx.schemaRead();
             Iterable<IndexDescriptor> indexesIterator;
-            Iterable<ConstraintDescriptor> constraintsIterator;
-
-            final Predicate<ConstraintDescriptor> isNodeConstraint = Util::isNodeCategory;
+            Iterable<ConstraintDefinition> constraintsIterator;
+            final Predicate<ConstraintDefinition> isNodeConstraint = constraintDefinition ->
+                    Util.isNodeCategory(constraintDefinition.getConstraintType());
+            
             if (includeLabels.isEmpty()) {
 
                 Iterator<IndexDescriptor> allIndex = schemaRead.indexesGetAll();
@@ -363,23 +366,18 @@ public class Schemas {
                             }
                         }));
 
-                Iterable<ConstraintDescriptor> allConstraints = () -> schemaRead.constraintsGetAll();
+                Iterable<ConstraintDefinition> allConstraints = schema.getConstraints();
                 constraintsIterator = StreamSupport.stream(allConstraints.spliterator(),false)
                         .filter(isNodeConstraint)
-                        .filter(constraint -> Arrays.stream(constraint.schema().getEntityTokenIds()).noneMatch(id -> {
-                            try {
-                                return excludeLabels.contains(tokenRead.nodeLabelName(id));
-                            } catch (LabelNotFoundKernelException e) {
-                                return false;
-                            }
-                        }))
+                        .filter(constraint -> !excludeLabels.contains(constraint.getLabel().name()))
                         .collect(Collectors.toList());
             } else {
                 constraintsIterator = includeLabels.stream()
                         .filter(label -> !excludeLabels.contains(label) && tokenRead.nodeLabel(label) != -1)
                         .flatMap(label -> {
-                            Iterable<ConstraintDescriptor> indexesForLabel = () -> schemaRead.constraintsGetForLabel(tokenRead.nodeLabel(label));
-                            return StreamSupport.stream(indexesForLabel.spliterator(), false);
+                            Iterable<ConstraintDefinition> constraintsForType = schema.getConstraints(Label.label(label));
+                            return StreamSupport.stream(constraintsForType.spliterator(), false)
+                                    .filter(isNodeConstraint);
                         })
                         .collect(Collectors.toList());
 
@@ -393,8 +391,7 @@ public class Schemas {
             }
 
             Stream<IndexConstraintNodeInfo> constraintNodeInfoStream = StreamSupport.stream(constraintsIterator.spliterator(), false)
-                    .filter(ConstraintDescriptor::isNodePropertyExistenceConstraint)
-                    .map(constraintDescriptor -> this.nodeInfoFromConstraintDescriptor(constraintDescriptor, tokenRead))
+                    .map(constraintDescriptor -> nodeInfoFromConstraintDefinition(constraintDescriptor, tokenRead))
                     .sorted(Comparator.comparing(i -> i.label.toString()));
 
             Stream<IndexConstraintNodeInfo> indexNodeInfoStream = StreamSupport.stream(indexesIterator.spliterator(), false)
@@ -452,7 +449,7 @@ public class Schemas {
                 Iterable<ConstraintDefinition> allConstraints = schema.getConstraints();
                 constraintsIterator = StreamSupport.stream(allConstraints.spliterator(),false)
                         .filter(isRelConstraint)
-                        .filter(index -> !excludeRelationships.contains(index.getRelationshipType().name()))
+                        .filter(constraint -> !excludeRelationships.contains(constraint.getRelationshipType().name()))
                         .collect(Collectors.toList());
 
                 Iterator<IndexDescriptor> allIndex = schemaRead.indexesGetAll();
@@ -472,28 +469,27 @@ public class Schemas {
     }
 
     /**
-     * ConstraintInfo info from ConstraintDescriptor
+     * ConstraintInfo info from ConstraintDefinition
      *
-     * @param constraintDescriptor
+     * @param constraintDefinition
      * @param tokens
      * @return
      */
-    private IndexConstraintNodeInfo nodeInfoFromConstraintDescriptor(ConstraintDescriptor constraintDescriptor, TokenNameLookup tokens) {
-        String labelName =  tokens.labelGetName(constraintDescriptor.schema().getLabelId());
-        List<String> properties = new ArrayList<>();
-        Arrays.stream(constraintDescriptor.schema().getPropertyIds()).forEach((i) -> properties.add(tokens.propertyKeyGetName(i)));
+    private IndexConstraintNodeInfo nodeInfoFromConstraintDefinition(ConstraintDefinition constraintDefinition, TokenNameLookup tokens) {
+        String labelName = constraintDefinition.getLabel().name();
+        List<String> properties = Iterables.asList(constraintDefinition.getPropertyKeys());
         return new IndexConstraintNodeInfo(
                 // Pretty print for index name
                 String.format(":%s(%s)", labelName, StringUtils.join(properties, ",")),
                 labelName,
                 properties,
                 StringUtils.EMPTY,
-                ConstraintType.NODE_PROPERTY_EXISTENCE.toString(),
+                constraintDefinition.getConstraintType().name(),
                 "NO FAILURE",
                 0,
                 0,
                 0,
-                constraintDescriptor.userDescription(tokens)
+                ktx.schemaRead().constraintGetForName(constraintDefinition.getName()).userDescription(tokens)
         );
     }
 
@@ -523,10 +519,12 @@ public class Schemas {
                 .mapToObj(tokens::propertyKeyGetName)
                 .collect(Collectors.toList());
         
+        // Pretty print for index name
+        final String schemaInfoName = getSchemaInfoName(labelName, properties);
+        final String userDescription = indexDescriptor.userDescription(tokens);
         try {
             return new IndexConstraintNodeInfo(
-                    // Pretty print for index name
-                    getSchemaInfoName(labelName, properties),
+                    schemaInfoName,
                     labelName,
                     properties,
                     schemaRead.indexGetState(indexDescriptor).toString(),
@@ -535,19 +533,18 @@ public class Schemas {
                     schemaRead.indexGetPopulationProgress(indexDescriptor).getCompleted() / schemaRead.indexGetPopulationProgress(indexDescriptor).getTotal() * 100,
                     schemaRead.indexSize(indexDescriptor),
                     schemaRead.indexUniqueValuesSelectivity(indexDescriptor),
-                    indexDescriptor.userDescription(tokens)
+                    userDescription
             );
         } catch(IndexNotFoundKernelException e) {
             return new IndexConstraintNodeInfo(
-                    // Pretty print for index name
-                    getSchemaInfoName(labelName, properties),
+                    schemaInfoName,
                     labelName,
                     properties,
-                    "NOT_FOUND",
+                    IDX_NOT_FOUND,
                     getIndexType(indexDescriptor),
-                    "NOT_FOUND",
+                    IDX_NOT_FOUND,
                     0,0,0,
-                    indexDescriptor.userDescription(tokens)
+                    userDescription
             );
         }
     }
@@ -560,27 +557,28 @@ public class Schemas {
         if (length == 0) {
             relName = TOKEN_REL_TYPE;
         } else {
-            final List<String> labels = IntStream.of(relIds)
+            final List<String> rels = IntStream.of(relIds)
                     .mapToObj(tokens::relationshipTypeGetName)
                     .sorted()
                     .collect(Collectors.toList());
-            relName = labels.size() > 1 ? labels : labels.get(0);
+            relName = rels.size() > 1 ? rels : rels.get(0);
         }
         final List<String> properties = Arrays.stream(indexDescriptor.schema().getPropertyIds())
                 .mapToObj(tokens::propertyKeyGetName)
                 .collect(Collectors.toList());
+        
+        // Pretty print for index name
+        final String name = getSchemaInfoName(relName, properties);
+        final String schemaType = getIndexType(indexDescriptor);
+        
+        String indexStatus;
         try {
-            return new IndexConstraintRelationshipInfo(getSchemaInfoName(relName, properties), "INDEX", properties, schemaRead.indexGetState(indexDescriptor).toString(), relName);
+            indexStatus = schemaRead.indexGetState(indexDescriptor).toString();
         } catch (IndexNotFoundKernelException e) {
-            return new IndexConstraintRelationshipInfo(
-                    // Pretty print for index name
-                    getSchemaInfoName(relName, properties),
-                    getIndexType(indexDescriptor),
-                    properties,
-                    "NOT_FOUND",
-                    relName
-            );
+            indexStatus = IDX_NOT_FOUND;
         }
+
+        return new IndexConstraintRelationshipInfo(name, schemaType, properties, indexStatus, relName);
     }
 
     /**
@@ -600,7 +598,7 @@ public class Schemas {
     }
 
     private static String getIndexType(IndexDescriptor indexDescriptor) {
-        return indexDescriptor.isUnique() ? "UNIQUENESS" : "INDEX";
+        return indexDescriptor.getIndexType().name();
     }
 
     private String getSchemaInfoName(Object labelOrType, List<String> properties) {

--- a/core/src/test/java/apoc/schema/SchemasTest.java
+++ b/core/src/test/java/apoc/schema/SchemasTest.java
@@ -58,7 +58,7 @@ public class SchemasTest {
         assertEquals(":Foo(bar)", r.get("name"));
         assertEquals("ONLINE", r.get("status"));
         assertEquals("Foo", r.get("label"));
-        assertEquals("INDEX", r.get("type"));
+        assertEquals("RANGE", r.get("type"));
         assertEquals("bar", ((List<String>) r.get("properties")).get(0));
         assertEquals("NO FAILURE", r.get("failure"));
         assertEquals(100d, r.get("populationProgress"));
@@ -74,7 +74,7 @@ public class SchemasTest {
         assertEquals(":Foo(bar)", r.get("name"));
         assertEquals("ONLINE", r.get("status"));
         assertEquals("Foo", r.get("label"));
-        assertEquals("INDEX", r.get("type"));
+        assertEquals("RANGE", r.get("type"));
         assertEquals("bar", ((List<String>) r.get("properties")).get(0));
         assertEquals("NO FAILURE", r.get("failure"));
         assertEquals(100d, r.get("populationProgress"));
@@ -86,7 +86,7 @@ public class SchemasTest {
         assertEquals(":Person(name)", r.get("name"));
         assertEquals("ONLINE", r.get("status"));
         assertEquals("Person", r.get("label"));
-        assertEquals("INDEX", r.get("type"));
+        assertEquals("TEXT", r.get("type"));
         assertEquals("name", ((List<String>) r.get("properties")).get(0));
         assertEquals("NO FAILURE", r.get("failure"));
         assertEquals(100d, r.get("populationProgress"));
@@ -336,7 +336,7 @@ public class SchemasTest {
             assertEquals(":Foo(bar)", r.get("name"));
             assertEquals("ONLINE", r.get("status"));
             assertEquals("Foo", r.get("label"));
-            assertEquals("INDEX", r.get("type"));
+            assertEquals("RANGE", r.get("type"));
             assertEquals("bar", ((List<String>) r.get("properties")).get(0));
             assertEquals("NO FAILURE", r.get("failure"));
             assertEquals(100d, r.get("populationProgress"));
@@ -355,7 +355,7 @@ public class SchemasTest {
             assertEquals(":KNOWS(id,since)", row.get("name"));
             assertEquals("ONLINE", row.get("status"));
             assertEquals("KNOWS", row.get("relationshipType"));
-            assertEquals("INDEX", row.get("type"));
+            assertEquals("RANGE", row.get("type"));
             assertEquals(List.of("id", "since"), row.get("properties"));
         });
     }
@@ -396,13 +396,29 @@ public class SchemasTest {
         db.executeTransactionally("CREATE CONSTRAINT FOR (bar:Bar) REQUIRE bar.foo IS UNIQUE");
         awaitIndexesOnline();
 
-        testResult(db, "CALL apoc.schema.nodes()", (result) -> {
+        testResult(db, "CALL apoc.schema.nodes() " +
+                "YIELD label, properties, name, userDescription, type, status " +
+                "RETURN * ORDER BY type", (result) -> {
             Map<String, Object> r = result.next();
+            
+            assertEquals(":Bar(foo)", r.get("name"));
+            assertEquals("Bar", r.get("label"));
+            assertEquals("foo", ((List<String>) r.get("properties")).get(0));
+            
+            assertEquals("RANGE", r.get("type"));
+            assertEquals("ONLINE", r.get("status"));
+            final String expectedUserDescBarIdx = "name='constraint_4791de3e', type='RANGE', schema=(:Bar {foo}), indexProvider='range-1.0', owningConstraint=4";
+            Assertions.assertThat(r.get("userDescription").toString()).contains(expectedUserDescBarIdx);
+            r = result.next();
 
             assertEquals(":Bar(foo)", r.get("name"));
             assertEquals("Bar", r.get("label"));
-            assertEquals("UNIQUENESS", r.get("type"));
             assertEquals("foo", ((List<String>) r.get("properties")).get(0));
+            
+            assertEquals("UNIQUENESS", r.get("type"));
+            assertEquals("", r.get("status"));
+            final String expectedUserDescBarCons = "name='constraint_4791de3e', type='UNIQUENESS', schema=(:Bar {foo}), ownedIndex=3";
+            Assertions.assertThat(r.get("userDescription").toString()).contains(expectedUserDescBarCons);
 
             assertFalse(result.hasNext());
         });
@@ -410,22 +426,63 @@ public class SchemasTest {
 
     @Test
     public void testIndexAndUniquenessConstraintOnNode() {
-        db.executeTransactionally("CREATE INDEX FOR (n:Foo) ON (n.foo)");
-        db.executeTransactionally("CREATE CONSTRAINT FOR (bar:Bar) REQUIRE bar.bar IS UNIQUE");
+        db.executeTransactionally("CREATE INDEX foo_idx FOR (n:Foo) ON (n.foo)");
+        db.executeTransactionally("CREATE CONSTRAINT bar_unique FOR (bar:Bar) REQUIRE bar.bar IS UNIQUE");
         awaitIndexesOnline();
-
-        testResult(db, "CALL apoc.schema.nodes()", (result) -> {
+        
+        testResult(db, "CALL apoc.schema.nodes() " +
+                "YIELD label, type, properties, status, userDescription, name " +
+                "RETURN * ORDER BY label, type", (result) -> {
             Map<String, Object> r = result.next();
 
-            assertEquals("Bar", r.get("label"));
+            assertionBarUniqueCons(r);
+
+            assertEquals("RANGE", r.get("type"));
+            assertEquals("ONLINE", r.get("status"));
+            final String expectedUserDescBarIdx = "name='bar_unique', type='RANGE', schema=(:Bar {bar}), indexProvider='range-1.0', owningConstraint";
+            Assertions.assertThat(r.get("userDescription").toString()).contains(expectedUserDescBarIdx);
+
+            r = result.next();
+
+            assertionBarUniqueCons(r);
+
             assertEquals("UNIQUENESS", r.get("type"));
-            assertEquals("bar", ((List<String>) r.get("properties")).get(0));
+            assertEquals("", r.get("status"));
+            final String expectedUserDescBarCons = "name='bar_unique', type='UNIQUENESS', schema=(:Bar {bar}), ownedIndex";
+            Assertions.assertThat(r.get("userDescription").toString()).contains(expectedUserDescBarCons);
 
             r = result.next();
             assertEquals("Foo", r.get("label"));
-            assertEquals("INDEX", r.get("type"));
+            assertEquals("RANGE", r.get("type"));
             assertEquals("foo", ((List<String>) r.get("properties")).get(0));
             assertEquals("ONLINE", r.get("status"));
+            assertEquals(":Foo(foo)", r.get("name"));
+            final String expectedUserDescFoo = "name='foo_idx', type='RANGE', schema=(:Foo {foo}), indexProvider='range-1.0' )";
+            Assertions.assertThat(r.get("userDescription").toString()).contains(expectedUserDescFoo);
+
+            assertFalse(result.hasNext());
+        });
+    }
+
+    private static void assertionBarUniqueCons(Map<String, Object> r) {
+        assertEquals("Bar", r.get("label"));
+        assertEquals(":Bar(bar)", r.get("name"));
+        assertEquals("bar", ((List<String>) r.get("properties")).get(0));
+    }
+
+    @Test
+    public void testSchemaNodesPointIndex() {
+        db.executeTransactionally("CREATE POINT INDEX pointIdx FOR (n:Baz) ON (n.baz)");
+        
+        testResult(db, "CALL apoc.schema.nodes()", (result) -> {
+            Map<String, Object> r = result.next();
+
+            assertEquals("Baz", r.get("label"));
+            assertEquals("POINT", r.get("type"));
+            assertEquals("baz", ((List<String>) r.get("properties")).get(0));
+            assertEquals("ONLINE", r.get("status"));
+            final String expectedUserDesc = "name='pointIdx', type='POINT', schema=(:Baz {baz}), indexProvider='point-1.0'";
+            Assertions.assertThat( r.get( "userDescription").toString() ).contains(expectedUserDesc);
 
             assertFalse(result.hasNext());
         });
@@ -731,7 +788,7 @@ public class SchemasTest {
                         r = result.next();
 
                         assertEquals(":SINCE(year)", r.get("name"));
-                        assertEquals("INDEX", r.get("type"));
+                        assertEquals("RANGE", r.get("type"));
                         assertEquals("SINCE", r.get("relationshipType"));
                         assertEquals("year", ((List<String>) r.get("properties")).get(0));
                         assertTrue(!result.hasNext());
@@ -756,7 +813,7 @@ public class SchemasTest {
         ));
         relConstraints.add(new IndexConstraintRelationshipInfo(
                 ":SINCE(year)",
-                "INDEX",
+                "RANGE",
                 List.of("year"),
                 "ONLINE",
                 "SINCE"
@@ -770,7 +827,7 @@ public class SchemasTest {
         ));
         relConstraints.add(new IndexConstraintRelationshipInfo(
                 ":LIKED(when)",
-                "INDEX",
+                "RANGE",
                 List.of("when"),
                 "ONLINE",
                 "LIKED"
@@ -784,16 +841,17 @@ public class SchemasTest {
         ));
         relConstraints.add(new IndexConstraintRelationshipInfo(
                 ":KNOW(how)",
-                "INDEX",
+                "RANGE",
                 List.of("how"),
                 "ONLINE",
                 "KNOW"
         ));
 
-        testResult(db, "CALL apoc.schema.relationships({})",
+        testResult(db, "CALL apoc.schema.relationships",
                     result -> {
                         while  (result.hasNext()) {
                             Map<String, Object> r = result.next();
+                            System.out.println("r = " + r);
 
                             assertEquals(1, relConstraints.stream().filter(
                                     c -> c.name.equals(r.get("name")) &&
@@ -816,17 +874,19 @@ public class SchemasTest {
             assertEquals(":" + TOKEN_LABEL + "()", row.get("name"));
             assertEquals("ONLINE", row.get("status"));
             assertEquals(TOKEN_LABEL, row.get("label"));
-            assertEquals("INDEX", row.get("type"));
+            assertEquals("LOOKUP", row.get("type"));
             assertTrue(((List)row.get("properties")).isEmpty());
             assertEquals("NO FAILURE", row.get("failure"));
             assertEquals(100d, row.get("populationProgress"));
             assertEquals(1d, row.get("valuesSelectivity"));
-            assertTrue(row.get("userDescription").toString().contains("name='node_label_lookup_index', type='LOOKUP', schema=(:<any-labels>), indexProvider='token-lookup-1.0' )"));
+            final String expectedUserDesc = "name='node_label_lookup_index', type='LOOKUP', schema=(:<any-labels>), indexProvider='token-lookup-1.0'";
+            Assertions.assertThat( row.get( "userDescription").toString() ).contains(expectedUserDesc);
         });
+        
         testCall(db, "CALL apoc.schema.relationships()", (row) -> {
             assertEquals(":" + TOKEN_REL_TYPE + "()", row.get("name"));
             assertEquals("ONLINE", row.get("status"));
-            assertEquals("INDEX", row.get("type"));
+            assertEquals("LOOKUP", row.get("type"));
             assertEquals(TOKEN_REL_TYPE, row.get("relationshipType"));
             assertTrue(((List)row.get("properties")).isEmpty());
         });
@@ -853,7 +913,7 @@ public class SchemasTest {
             assertEquals(":[Blah, Moon],(weightProp,anotherProp)", r.get("name"));
             assertEquals("ONLINE", r.get("status"));
             assertEquals(List.of("Blah", "Moon"), r.get("label"));
-            assertEquals("INDEX", r.get("type"));
+            assertEquals("FULLTEXT", r.get("type"));
             assertEquals(List.of("weightProp", "anotherProp"), r.get("properties"));
             assertEquals("NO FAILURE", r.get("failure"));
             assertEquals(100d, r.get("populationProgress"));
@@ -870,7 +930,7 @@ public class SchemasTest {
             assertEquals("ONLINE", r.get("status"));
             assertEquals(List.of("TYPE_1", "TYPE_2"), r.get("relationshipType"));
             assertEquals(List.of("alpha", "beta"), r.get("properties"));
-            assertEquals("INDEX", r.get("type"));
+            assertEquals("FULLTEXT", r.get("type"));
         });
     }
 


### PR DESCRIPTION
Doubt:
- CREATE CONSTRAINT FOR ()-[since:SINCE]-() REQUIRE since.year IS UNIQUE --> ritorna 2 risultati  -----> returns ALL indexes and constraints information for all node labels in the database.

- Schemas --> `.filter(indexDescriptor -> !indexDescriptor.isUnique())`


- Removed "INDEX" hardcoded in relationshipInfoFromIndexDescription
- Simplified relationshipInfoFromIndexDescription


1st way: this one
2nd way: by using ConstraintDescriptor
```
public static ConstraintType getConstraintType(ConstraintDescriptor descriptor) {
    if (descriptor.isNodeUniquenessConstraint()) return ConstraintType.UNIQUENESS;
    if (descriptor.isNodeKeyConstraint()) return ConstraintType.NODE_KEY;
    if (descriptor.isNodePropertyExistenceConstraint()) return ConstraintType.NODE_PROPERTY_EXISTENCE;
    if (descriptor.isRelationshipUniquenessConstraint()) return ConstraintType.RELATIONSHIP_UNIQUENESS;
    if (descriptor.isRelationshipPropertyExistenceConstraint()) return ConstraintType.RELATIONSHIP_PROPERTY_EXISTENCE;
    if (descriptor.isRelationshipKeyConstraint()) return ConstraintType.RELATIONSHIP_KEY;

    return ConstraintType.UNIQUENESS;
}
```